### PR TITLE
refactor : Fix comment api to list with out token

### DIFF
--- a/article_detail.html
+++ b/article_detail.html
@@ -33,12 +33,7 @@
         <!-- 댓글 리스팅 영역 -->
         <div class="container w-50 mt-5">
             <h5>댓글</h5>
-            <ul class="list-group list-group-flush" id="comment-list">
-                <li class="list-group-item">
-                    <h5>댓글작성자</h5>
-                    An item
-                </li>
-            </ul>
+            <ul class="list-group list-group-flush" id="comment-list"></ul>
         </div>
         <!-- 댓글 작성 영역 -->
         <div class="container w-50 mt-5">

--- a/scripts/api.js
+++ b/scripts/api.js
@@ -364,12 +364,7 @@ async function getBookmarkArticles(){
 
 async function getComments(articleId){
     let token = localStorage.getItem("access")
-    const response = await fetch(`${backend_base_url}/article/${articleId}/comment/`, {
-        headers: {
-            "Authorization": `Bearer ${token}`
-        },
-        method: 'GET'
-    })
+    const response = await fetch(`${backend_base_url}/article/${articleId}/comment/`)
     
     if(response.status == 200) {
         response_json = await response.json()


### PR DESCRIPTION
1. 백엔드 수정사항에 맞추어 토큰 없이도 댓글을 리스팅하도록 수정했습니다.
2. 아티클 디테일 페이지에서 댓글 기본형이 없도록 지웠습니다.